### PR TITLE
Use deployers bin/php to execute magento_bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_STORE
+vendor/

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Also check `app:config:dump` issue and workaround here:
 	```php
 	// deploy.php
 	task('files:static_assets', '
-		{{magento_bin}} setup:static-content:deploy en_US {{static_deploy_options}}
-		{{magento_bin}} setup:static-content:deploy de_CH {{static_deploy_options}}
-		{{magento_bin}} setup:static-content:deploy fr_FR {{static_deploy_options}}
+		{{bin/php}} {{magento_bin}} setup:static-content:deploy en_US {{static_deploy_options}}
+		{{bin/php}} {{magento_bin}} setup:static-content:deploy de_CH {{static_deploy_options}}
+		{{bin/php}} {{magento_bin}} setup:static-content:deploy fr_FR {{static_deploy_options}}
 	');
 	```
 	

--- a/recipe/magento_2_1.php
+++ b/recipe/magento_2_1.php
@@ -24,7 +24,7 @@ set('git_tty', true);
 
 # ----- Magento properties -------
 set('magento_dir', 'magento');
-set('magento_bin', '{{bin/php}} {{magento_dir}}/bin/magento');
+set('magento_bin', '{{magento_dir}}/bin/magento');
 
 set('shared_files', [
     '{{magento_dir}}/app/etc/env.php',

--- a/recipe/magento_2_1.php
+++ b/recipe/magento_2_1.php
@@ -24,7 +24,7 @@ set('git_tty', true);
 
 # ----- Magento properties -------
 set('magento_dir', 'magento');
-set('magento_bin', '{{magento_dir}}/bin/magento');
+set('magento_bin', '{{bin/php}} {{magento_dir}}/bin/magento');
 
 set('shared_files', [
     '{{magento_dir}}/app/etc/env.php',

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -7,6 +7,6 @@
 
 namespace Deployer;
 
-task('cache:clear:magento', '{{magento_bin}} cache:flush');
+task('cache:clear:magento', '{{bin/php}} {{magento_bin}} cache:flush');
 
 task('cache:clear', 'cache:clear:magento');

--- a/recipe/magento_2_1/database.php
+++ b/recipe/magento_2_1/database.php
@@ -7,4 +7,4 @@
 
 namespace Deployer;
 
-task('database:upgrade', '{{magento_bin}} setup:upgrade --keep-generated');
+task('database:upgrade', '{{bin/php}} {{magento_bin}} setup:upgrade --keep-generated');

--- a/recipe/magento_2_1/files.php
+++ b/recipe/magento_2_1/files.php
@@ -10,8 +10,8 @@ namespace Deployer;
 set('languages', 'en_US');
 set('static_deploy_options', '--exclude-theme=Magento/blank');
 
-task('files:compile', '{{magento_bin}} setup:di:compile');
-task('files:static_assets', '{{magento_bin}} setup:static-content:deploy {{languages}} {{static_deploy_options}}');
+task('files:compile', '{{bin/php}} {{magento_bin}} setup:di:compile');
+task('files:static_assets', '{{bin/php}} {{magento_bin}} setup:static-content:deploy {{languages}} {{static_deploy_options}}');
 task('files:permissions',
     'cd {{magento_dir}} && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; ' .
     '&& find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} \; && chmod u+x bin/magento');

--- a/recipe/magento_2_1/maintenance.php
+++ b/recipe/magento_2_1/maintenance.php
@@ -11,7 +11,7 @@ task('maintenance:set', function () {
     # IMPORTANT: do not use {{current_path}} for the "-f" check.
     # {{current_path}} returns error if symlink does not exists
     test('[ -f {{deploy_path}}/current/{{magento_bin}} ]') ?
-        run('{{current_path}}/{{magento_bin}} maintenance:enable') :
+        run('{{bin/php}} {{current_path}}/{{magento_bin}} maintenance:enable') :
         writeln('Skipped -> current not found');
 });
 
@@ -23,6 +23,6 @@ task('maintenance:unset', function () {
         return;
     }
     test('[ -f {{deploy_path}}/current/{{magento_dir}}/var/.maintenance.flag ]') ?
-        run('{{current_path}}/{{magento_bin}} maintenance:disable') :
+        run('{{bin/php}} {{current_path}}/{{magento_bin}} maintenance:disable') :
         writeln('Skipped -> maintenance is already unset');
 });

--- a/recipe/magento_2_2/config.php
+++ b/recipe/magento_2_2/config.php
@@ -16,7 +16,7 @@ const OUTPUT_CONFIG_IMPORT_NEEDED = 'This command is unavailable right now. ' .
 set('config_import_needed', function () {
     try {
         // NOTE: Workaround until "app:config:status" is available on Magento 2.2.3
-        run('{{release_path}}/{{magento_bin}} config:set workaround/check/config_status 1');
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} config:set workaround/check/config_status 1');
     } catch (ProcessFailedException $e) {
         if (trim($e->getProcess()->getOutput()) == OUTPUT_CONFIG_IMPORT_NEEDED) {
             return true;
@@ -31,6 +31,6 @@ set('config_import_needed', function () {
 
 task('config:import', function () {
     get('config_import_needed') ?
-        run('{{release_path}}/{{magento_bin}} app:config:import') :
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} app:config:import') :
         writeln('Skipped -> App config is up to date');
 });

--- a/recipe/magento_2_2/crontab.php
+++ b/recipe/magento_2_2/crontab.php
@@ -7,4 +7,4 @@
 
 namespace Deployer;
 
-task('crontab:update', '{{magento_bin}} cron:install --force');
+task('crontab:update', '{{bin/php}} {{magento_bin}} cron:install --force');

--- a/recipe/magento_2_2/database.php
+++ b/recipe/magento_2_2/database.php
@@ -14,7 +14,7 @@ const DB_UPDATE_NEEDED_EXIT_CODE = 2;
 
 set('database_upgrade_needed', function () {
     try {
-        run('{{release_path}}/{{magento_bin}} setup:db:status');
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:db:status');
     } catch (ProcessFailedException $e) {
         if ($e->getProcess()->getExitCode() == DB_UPDATE_NEEDED_EXIT_CODE) {
             return true;
@@ -31,6 +31,6 @@ set('database_upgrade_needed', function () {
 
 task('database:upgrade', function () {
     get('database_upgrade_needed') ?
-        run('{{release_path}}/{{magento_bin}} setup:upgrade --keep-generated') :
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:upgrade --keep-generated') :
         writeln('Skipped -> All Modules are up to date');
 });


### PR DESCRIPTION
This PR fixes #2 and enables this deployer extension to work on build machines with different versions of php installed