### PR TITLE
Delete cache name of exclude

### DIFF
--- a/config/artifact.excludes
+++ b/config/artifact.excludes
@@ -1,4 +1,5 @@
-page_cache
+var/cache
+var/page_cache
 _cache
 pub/media
 env.php

--- a/config/artifact.excludes
+++ b/config/artifact.excludes
@@ -1,4 +1,3 @@
-cache
 page_cache
 _cache
 pub/media


### PR DESCRIPTION
If you exclude `cache` from tar.gz you will exclude some folders like:
https://github.com/magento/magento2/tree/2.2-develop/app/code/Magento/Backend/view/adminhtml/templates/system/cache