### PR TITLE
Check if current path exists before crontab update

### DIFF
--- a/recipe/magento_2_2/crontab.php
+++ b/recipe/magento_2_2/crontab.php
@@ -7,7 +7,9 @@
 
 namespace Deployer;
 
-task('crontab:update', '
-    {{bin/php}} {{current_path}}/{{magento_bin}} cron:remove;
-    {{bin/php}} {{release_path}}/{{magento_bin}} cron:install;
-');
+task('crontab:update', function () {
+    if (test('[ -L {{deploy_path}}/current ]')) {
+        run("{{bin/php}} {{current_path}}/{{magento_bin}} cron:remove");
+    }
+    run("{{bin/php}} {{release_path}}/{{magento_bin}} cron:install");
+});


### PR DESCRIPTION
Check if current path exists before crontab update.
I use `if (test('[ -L {{deploy_path}}/current ]')) {` instead of `if (test('[ -L {{current_path}} ]')) {` because if you see function:  [common.php](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L92) is trying to readlink and fail.

The first time you deploy will fail if not checked before if path exists.