### PR TITLE
Cache:clear need invoke to cache:clear:magento

### DIFF
--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -9,4 +9,6 @@ namespace Deployer;
 
 task('cache:clear:magento', '{{bin/php}} {{magento_bin}} cache:flush');
 
-task('cache:clear', 'cache:clear:magento');
+task('cache:clear', function(){
+	invoke('cache:clear:magento');
+});


### PR DESCRIPTION
If not invoke to `cache:clear:magento` you get an error:

```
➤ Executing task cache:clear
In Client.php line 96:                                                                                         
  The command "cd /var/www/vhost/magento2/releases/1 && (cache:clear:magento)" failed. 
```