### PR TITLE
Add `dereference` flag to tar command

### DIFF
--- a/recipe/magento_2_2/artifact.php
+++ b/recipe/magento_2_2/artifact.php
@@ -18,7 +18,7 @@ set('artifact_path', function () {
     return get('artifact_dir') . '/' . get('artifact_file');
 });
 
-task('artifact:package', 'tar --exclude-from={{artifact_excludes_file}} -czf {{artifact_path}} .');
+task('artifact:package', 'tar --exclude-from={{artifact_excludes_file}} -chzf {{artifact_path}} .');
 
 task('artifact:upload', function () {
     upload(get('artifact_path'), '{{release_path}}');


### PR DESCRIPTION
The `-h` flag will tell tar to dereference symlinks and archive the files instead of the symlink.

This way it is possible to have symlinked composer packages (path-repositories) outside of the magento root and still build an full release artifact.