### PR TITLE
files:permissions task now runs faster and is more concise

### DIFF
--- a/recipe/magento_2_1/files.php
+++ b/recipe/magento_2_1/files.php
@@ -14,8 +14,7 @@ task('files:compile', '{{bin/php}} {{magento_bin}} setup:di:compile');
 task('files:static_assets', '{{bin/php}} {{magento_bin}} setup:static-content:deploy {{languages}} {{static_deploy_options}}');
 task(
     'files:permissions',
-    'cd {{magento_dir}} && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} \; ' .
-    '&& find var vendor pub/static pub/media app/etc -type d -exec chmod g+w {} \; && chmod u+x bin/magento'
+    'cd {{magento_dir}} && chmod -R g+w var vendor pub/static pub/media app/etc && chmod u+x bin/magento'
 );
 
 desc('Generate Magento Files');


### PR DESCRIPTION
As far as I know, the only reason to split the files/directories up is if you want to give them different permissions. Usually directories are given execute perms so that it's possible to cd into, but as r-x is the default, I guess it wasn't needed (as per official Magento devdocs https://devdocs.magento.com/guides/v2.3/comp-mgr/upgrader/upgrade.html)

Solves #27 

