### PR TITLE
No setup upgrade but db-schema and db-data upgrade

### DIFF
--- a/recipe/magento_2_1/database.php
+++ b/recipe/magento_2_1/database.php
@@ -7,4 +7,7 @@
 
 namespace Deployer;
 
-task('database:upgrade', '{{bin/php}} {{magento_bin}} setup:upgrade --keep-generated');
+task('database:upgrade', function () {
+    run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:db-schema:upgrade --no-interaction');
+    run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:db-data:upgrade --no-interaction');
+});

--- a/recipe/magento_2_2/database.php
+++ b/recipe/magento_2_2/database.php
@@ -30,7 +30,10 @@ set('database_upgrade_needed', function () {
 });
 
 task('database:upgrade', function () {
-    get('database_upgrade_needed') ?
-        run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:upgrade --keep-generated --no-interaction') :
+    if (get('database_upgrade_needed')) {
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:db-schema:upgrade --no-interaction');
+        run('{{bin/php}} {{release_path}}/{{magento_bin}} setup:db-data:upgrade --no-interaction');
+    } else {
         writeln('Skipped -> All Modules are up to date');
+    }
 });


### PR DESCRIPTION
When doing a setup upgrade you enable modules into config.php which where potentially not included on checkout. This enables the modules and executes their setup scripts. This is not what you want as your deployed project should not change state during deploy. Using db-schema & db-data upgrade you only execute setup scripts of already enabled modules.