### PR TITLE
Trigger deploy:failed task if deploy-artifact fails

### DIFF
--- a/recipe/magento_2_2.php
+++ b/recipe/magento_2_2.php
@@ -56,6 +56,7 @@ task('deploy-artifact', [
     'cleanup',
     'success',
 ]);
+fail('deploy-artifact', 'deploy:failed');
 
 # ---- Deployment Flow
 desc('Deploy project');


### PR DESCRIPTION
The same is done for deploy by default (common.php recipe)

This allows hooks like `after('deploy:failed', 'deploy:unlock')`