### PR TITLE
Enable caches in deploy task

### DIFF
--- a/deploy.php.sample_2_1
+++ b/deploy.php.sample_2_1
@@ -15,6 +15,8 @@ set('magento_dir', 'magento');
 set('repository', '');
 // Space separated list of languages for static-content:deploy
 set('languages', 'en_US');
+// Enable all caches after deployment
+set('cache_enabled_caches', 'all');
 
 // OPcache configuration
 task('cache:clear:opcache', 'sudo systemctl reload php-fpm');

--- a/deploy.php.sample_2_2
+++ b/deploy.php.sample_2_2
@@ -15,6 +15,8 @@ set('magento_dir', 'magento');
 set('repository', '');
 // Space separated list of languages for static-content:deploy
 set('languages', 'en_US');
+// Enable all caches after deployment
+set('cache_enabled_caches', 'all');
 
 // OPcache configuration
 task('cache:clear:opcache', 'sudo systemctl reload php-fpm');

--- a/deploy.php.sample_2_2_5
+++ b/deploy.php.sample_2_2_5
@@ -15,6 +15,8 @@ set('magento_dir', 'magento');
 set('repository', '');
 // Space separated list of languages for static-content:deploy
 set('languages', 'en_US');
+// Enable all caches after deployment
+set('cache_enabled_caches', 'all');
 
 // OPcache configuration
 task('cache:clear:opcache', 'sudo systemctl reload php-fpm');

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -55,11 +55,9 @@ task('cache:enable', function () {
 
     if ($enabledCaches === 'all') {
         run($command);
-        return;
     }
 
     if (is_array($enabledCaches)) {
-        $command = $command . ' ' . implode(' ', $enabledCaches);
-        run($command);
+        run($command . ' ' . implode(' ', $enabledCaches));
     }
 });

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -19,6 +19,11 @@ task('cache:clear:if-maintenance', function () {
         writeln('Skipped -> maintenance is not set');
 });
 
+set('cache_enabled_caches', 'all');
+
+/*
+ * One can provide specific caches as well.
+ * 
 set('cache_enabled_caches', 
     [
         'config',
@@ -37,18 +42,24 @@ set('cache_enabled_caches',
         'compiled_config',
     ]
 );
+ */
 
 task('cache:enable', function () {
     $enabledCaches = get('cache_enabled_caches');
     
-    if (!count($enabledCaches)) {
+    if (empty($enabledCaches)) {
         return;
     }
 
-    $command = sprintf(
-        '{{bin/php}} {{release_path}}/{{magento_bin}} cache:enable %s',
-        implode(' ', $enabledCaches)
-    );
+    $command = '{{bin/php}} {{release_path}}/{{magento_bin}} cache:enable';
 
-    run($command);
+    if ($enabledCaches === 'all') {
+        run($command);
+        return;
+    }
+
+    if (is_array($enabledCaches)) {
+        $command = $command . ' ' . implode(' ', $enabledCaches);
+        run($command);
+    }
 });

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -18,3 +18,34 @@ task('cache:clear:if-maintenance', function () {
         invoke('cache:clear:magento') :
         writeln('Skipped -> maintenance is not set');
 });
+
+set('cache_enabled_caches', 
+    [
+        'config',
+        'layout',
+        'block_html',
+        'collections',
+        'reflection',
+        'db_ddl',
+        'eav',
+        'customer_notification',
+        'target_rule',
+        'full_page',
+        'config_integration',
+        'config_integration_api',
+        'translate',
+        'config_webservice',
+        'compiled_config',
+    ]
+);
+
+task('cache:enable', function () {
+    $enabledCaches = get('cache_enabled_caches');
+    
+    if (!count($enabledCaches)) {
+        return;
+    }
+
+    $implodedCaches = implode(' ', $enabledCaches);
+    run(sprintf('{{bin/php}} {{magento_bin}} cache:enable %s', $implodedCaches));
+});

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -29,7 +29,6 @@ set('cache_enabled_caches',
         'db_ddl',
         'eav',
         'customer_notification',
-        'target_rule',
         'full_page',
         'config_integration',
         'config_integration_api',
@@ -46,6 +45,10 @@ task('cache:enable', function () {
         return;
     }
 
-    $implodedCaches = implode(' ', $enabledCaches);
-    run(sprintf('{{bin/php}} {{magento_bin}} cache:enable %s', $implodedCaches));
+    $command = sprintf(
+        '{{bin/php}} {{release_path}}/{{magento_bin}} cache:enable %s',
+        implode(' ', $enabledCaches)
+    );
+
+    run($command);
 });

--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -19,7 +19,16 @@ task('cache:clear:if-maintenance', function () {
         writeln('Skipped -> maintenance is not set');
 });
 
+/*
+ * By default, cache enabling is disabled.
+ */
+set('cache_enabled_caches', '');
+
+/*
+ * To enable all caches after deployment, configure the following:
+ * 
 set('cache_enabled_caches', 'all');
+ */
 
 /*
  * One can provide specific caches as well.

--- a/recipe/magento_2_2.php
+++ b/recipe/magento_2_2.php
@@ -81,6 +81,7 @@ task('deploy', [
     'deploy:symlink',
     'maintenance:unset',
     'cache:clear',
+    'cache:enable',
     'deploy:unlock',
     'cleanup',
     'success',

--- a/recipe/magento_2_2.php
+++ b/recipe/magento_2_2.php
@@ -52,6 +52,7 @@ task('deploy-artifact', [
     'deploy:symlink',
     'maintenance:unset',
     'cache:clear',
+    'cache:enable',
     'deploy:unlock',
     'cleanup',
     'success',


### PR DESCRIPTION
Sometimes a cache type gets disabled, for whatever [reason or bug](https://github.com/magento/magento2/issues/17634). 

It's nice to make sure the caches you **_want_** to be enabled **_are_** actually enabled.

This new task makes sure those caches are enabled. The variable `cache_enabled_caches` can be changed to add caches from own or 3rd party modules.