### PR TITLE
Share var/import and var/export

### DIFF
--- a/recipe/magento_2_1.php
+++ b/recipe/magento_2_1.php
@@ -47,6 +47,8 @@ set('shared_dirs', [
     '{{magento_dir}}/var/backups',
     '{{magento_dir}}/var/session',
     '{{magento_dir}}/var/report',
+    '{{magento_dir}}/var/import',
+    '{{magento_dir}}/var/export',
 ]);
 
 set('override_shared_dirs', [


### PR DESCRIPTION
These folders are by default used and so it would be great if they could be included in general in the shared directories.