### PR TITLE
Run dump-autoload with explicit --no-dev

### DIFF
--- a/recipe/magento_2_1/files.php
+++ b/recipe/magento_2_1/files.php
@@ -14,7 +14,7 @@ set('languages', 'en_US');
 set('static_deploy_options', '--exclude-theme=Magento/blank');
 
 task('files:compile', '{{bin/php}} {{magento_bin}} setup:di:compile');
-task('files:optimize-autoloader', '{{bin/composer}} dump-autoload --optimize --apcu');
+task('files:optimize-autoloader', '{{bin/composer}} dump-autoload --no-dev --optimize --apcu');
 task('files:static_assets', '{{bin/php}} {{magento_bin}} setup:static-content:deploy {{languages}} {{static_deploy_options}}');
 task(
     'files:permissions',


### PR DESCRIPTION
Explicitly run `dump-autoload` with `--no-dev` option.

We have found that on production, `autoload-dev` rules were also included in for example `vendor/composer/autload_files.php`.  When adding this flag, the `autoload-dev` rules are omitted, as they should be.